### PR TITLE
Extract http client, mock and test

### DIFF
--- a/lib/pusher/http_client.ex
+++ b/lib/pusher/http_client.ex
@@ -1,0 +1,44 @@
+defmodule Pusher.HttpClient do
+  use HTTPoison.Base
+  alias Signaturex.CryptoHelper
+
+  defp process_url(url), do: base_url <> url
+
+  defp base_url do
+    {:ok, host} = :application.get_env(:pusher, :host)
+    {:ok, port} = :application.get_env(:pusher, :port)
+    "#{host}:#{port}"
+  end
+
+  defp process_response_body(body) do
+    unless body == "", do: body |> JSX.decode!, else: nil
+  end
+
+  @doc """
+  More info at: http://pusher.com/docs/rest_api#authentication
+  """
+  def request(method, path, body \\ "", headers \\ [], options \\ []) do
+    qs_vals = build_qs(Keyword.get(options, :qs, %{}), body)
+    signed_qs_vals =
+    Signaturex.sign(app_key, secret, method, path, qs_vals)
+    |> Dict.merge(qs_vals)
+    |> URI.encode_query
+    super(method, path <> "?" <> signed_qs_vals, body, headers, options)
+  end
+
+  def build_qs(qs_vals, ""), do: qs_vals
+  def build_qs(qs_vals, body) do
+    Map.put(qs_vals, :body_md5, CryptoHelper.md5_to_string(body))
+  end
+
+  defp secret do
+    {:ok, secret} = :application.get_env(:pusher, :secret)
+    secret
+  end
+
+  defp app_key do
+    {:ok, app_key} = :application.get_env(:pusher, :app_key)
+    app_key
+  end
+
+end

--- a/mix.exs
+++ b/mix.exs
@@ -30,14 +30,14 @@ defmodule Pusher.Mixfile do
 
   defp deps do
     [ {:httpoison, "~> 0.6.0"},
-      {:signaturex, "~> 0.0.7"},
-      {:exjsx, "~> 3.0"},
-      {:meck, "~> 0.8.2", only: :test } ]
-   end
+    {:signaturex, "~> 0.0.7"},
+    {:exjsx, "~> 3.0"},
+    {:mock, "~> 0.1.1", only: [:dev, :test] } ]
+  end
 
-   defp package do
-     [ contributors: ["Eduardo Gurgel Pinho"],
-       licenses: ["MIT"],
-       links: %{"Github" => "https://github.com/edgurgel/pusher"} ]
-   end
+  defp package do
+    [ contributors: ["Eduardo Gurgel Pinho"],
+    licenses: ["MIT"],
+    links: %{"Github" => "https://github.com/edgurgel/pusher"} ]
+  end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -5,5 +5,6 @@
   "jsx": {:hex, :jsx, "2.4.0"},
   "meck": {:hex, :meck, "0.8.2"},
   "mimetypes": {:git, "git://github.com/spawngrid/mimetypes.git", "47d37a977a7d633199822bf6b08353007483d00f", [ref: "master"]},
+  "mock": {:hex, :mock, "0.1.1"},
   "signaturex": {:hex, :signaturex, "0.0.8"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.1"}}

--- a/test/pusher_test.exs
+++ b/test/pusher_test.exs
@@ -34,7 +34,7 @@ defmodule PusherTest do
   test_with_mock ".trigger sends the payload to a single channel", Pusher.HttpClient,
   [post!: fn("/apps/app_id/events", @expected_payload, _) -> @response_succesful_message end] do
     result = Pusher.trigger("event-name", "data", "channel")
-    expected = 200
+    expected = :ok
     assert result == expected
   end
 
@@ -46,7 +46,7 @@ defmodule PusherTest do
   test_with_mock ".channels calls the http client for list of channels", Pusher.HttpClient,
   [get!: fn("/apps/app_id/channels") -> @response_with_channel end] do
     result = Pusher.channels
-    expected = {200, %{"channels" => %{"test_channel" => %{}}}}
+    expected = {:ok, %{"test_channel" => %{}}}
     assert result == expected
   end
 
@@ -58,7 +58,7 @@ defmodule PusherTest do
   test_with_mock ".channel with an argument returns the user count for the channel", Pusher.HttpClient,
   [get!: fn("/apps/app_id/channels/test_info_channel", %{}, qs: %{info: "subscription_count"}) -> @response_with_channel_info end] do
     result = Pusher.channel "test_info_channel"
-    expected = {200, %{"occupied" => true, "user_count" => 42}}
+    expected = {:ok, %{"occupied" => true, "user_count" => 42}}
     assert result == expected
   end
 
@@ -70,7 +70,7 @@ defmodule PusherTest do
   test_with_mock ".users returns users in a presence channel", Pusher.HttpClient,
   [get!: fn("/apps/app_id/channels/presence-foobar/users") -> @response_with_users end] do
     result = Pusher.users "presence-foobar"
-    expected = {200, %{"users" => [%{"id" => 3}, %{"id" => 57}]}}
+    expected = {:ok, [%{"id" => 3}, %{"id" => 57}]}
     assert result == expected
   end
 

--- a/test/pusher_test.exs
+++ b/test/pusher_test.exs
@@ -1,5 +1,6 @@
 defmodule PusherTest do
   use ExUnit.Case
+  import Mock
   import Pusher
 
   test "configure! should change application env" do
@@ -12,4 +13,64 @@ defmodule PusherTest do
     assert vars[:app_key] == "app_key"
     assert vars[:secret]  == "secret"
   end
+
+  @response_succesful_message %HTTPoison.Response{
+    body: %{},
+    status_code: 200
+  }
+
+  @expected_payload %{
+    name: "event-name",
+    channels: ["channel"],
+    data: "data"
+  } |> JSX.encode!
+
+  test_with_mock ".trigger sends the payload to a single channel", Pusher.HttpClient,
+  [post!: fn("/apps/app_id/events", @expected_payload, _) -> @response_succesful_message end] do
+    :application.set_env(:pusher, :app_id, "app_id")
+    result = Pusher.trigger("event-name", "data", "channel")
+    expected = 200
+    assert result == expected
+  end
+
+  @response_with_channel %HTTPoison.Response{
+    body: %{"channels" => %{"test_channel" => %{}}},
+    status_code: 200
+  }
+
+  test_with_mock ".channels calls the http client for list of channels", Pusher.HttpClient,
+  [get!: fn("/apps/app_id/channels") -> @response_with_channel end] do
+    :application.set_env(:pusher, :app_id, "app_id")
+    result = Pusher.channels
+    expected = {200, %{"channels" => %{"test_channel" => %{}}}}
+    assert result == expected
+  end
+
+
+  @response_with_channel_info %HTTPoison.Response{
+    body: %{"occupied" => true, "user_count" => 42},
+    status_code: 200
+  }
+
+  test_with_mock ".channel with an argument returns the user count for the channel", Pusher.HttpClient,
+  [get!: fn("/apps/app_id/channels/test_info_channel", %{}, qs: %{info: "subscription_count"}) -> @response_with_channel_info end] do
+    :application.set_env(:pusher, :app_id, "app_id")
+    result = Pusher.channel "test_info_channel"
+    expected = {200, %{"occupied" => true, "user_count" => 42}}
+    assert result == expected
+  end
+
+  @response_with_users %HTTPoison.Response{
+    body: %{"users" => [%{"id" => 3}, %{"id" => 57}]},
+    status_code: 200
+  }
+
+  test_with_mock ".users returns users in a presence channel", Pusher.HttpClient,
+  [get!: fn("/apps/app_id/channels/presence-foobar/users") -> @response_with_users end] do
+    :application.set_env(:pusher, :app_id, "app_id")
+    result = Pusher.users "presence-foobar"
+    expected = {200, %{"users" => [%{"id" => 3}, %{"id" => 57}]}}
+    assert result == expected
+  end
+
 end

--- a/test/pusher_test.exs
+++ b/test/pusher_test.exs
@@ -3,13 +3,19 @@ defmodule PusherTest do
   import Mock
   import Pusher
 
+  # `setup` is called before each test is run
+  setup do
+    :application.set_env(:pusher, :app_id, "app_id")
+    {:ok, []}
+  end
+
   test "configure! should change application env" do
-    configure!("host", "port", "app_id", "app_key", "secret")
+    configure!("host", "port", "updated_app_id", "app_key", "secret")
     vars = :application.get_all_env(:pusher)
 
     assert vars[:host]    == "host"
     assert vars[:port]    == "port"
-    assert vars[:app_id]  == "app_id"
+    assert vars[:app_id]  == "updated_app_id"
     assert vars[:app_key] == "app_key"
     assert vars[:secret]  == "secret"
   end
@@ -27,7 +33,6 @@ defmodule PusherTest do
 
   test_with_mock ".trigger sends the payload to a single channel", Pusher.HttpClient,
   [post!: fn("/apps/app_id/events", @expected_payload, _) -> @response_succesful_message end] do
-    :application.set_env(:pusher, :app_id, "app_id")
     result = Pusher.trigger("event-name", "data", "channel")
     expected = 200
     assert result == expected
@@ -40,12 +45,10 @@ defmodule PusherTest do
 
   test_with_mock ".channels calls the http client for list of channels", Pusher.HttpClient,
   [get!: fn("/apps/app_id/channels") -> @response_with_channel end] do
-    :application.set_env(:pusher, :app_id, "app_id")
     result = Pusher.channels
     expected = {200, %{"channels" => %{"test_channel" => %{}}}}
     assert result == expected
   end
-
 
   @response_with_channel_info %HTTPoison.Response{
     body: %{"occupied" => true, "user_count" => 42},
@@ -54,7 +57,6 @@ defmodule PusherTest do
 
   test_with_mock ".channel with an argument returns the user count for the channel", Pusher.HttpClient,
   [get!: fn("/apps/app_id/channels/test_info_channel", %{}, qs: %{info: "subscription_count"}) -> @response_with_channel_info end] do
-    :application.set_env(:pusher, :app_id, "app_id")
     result = Pusher.channel "test_info_channel"
     expected = {200, %{"occupied" => true, "user_count" => 42}}
     assert result == expected
@@ -67,7 +69,6 @@ defmodule PusherTest do
 
   test_with_mock ".users returns users in a presence channel", Pusher.HttpClient,
   [get!: fn("/apps/app_id/channels/presence-foobar/users") -> @response_with_users end] do
-    :application.set_env(:pusher, :app_id, "app_id")
     result = Pusher.users "presence-foobar"
     expected = {200, %{"users" => [%{"id" => 3}, %{"id" => 57}]}}
     assert result == expected


### PR DESCRIPTION
Couple of things done in this PR:
1. Pulled out the logic of communicating via http with pusher into Pusher.HttpClient.
2. Replaced meck with mock as this wraps meck and makes it a bit easier to use in elixir.
3. Written some unit tests around Pusher module, mocking the Pusher.HttpClient
4. Updated the interface of the Pusher functions as it made more sense for it to return `{:ok, requested_info}` rather than the bare http response data.

There's no unit coverage around the HttpClient module as I think this would make more sense to do as integration/acceptance tests that actually talk to pusher. Need to have a think about how best to do this. Not sure if Pusher offers some test credentials that give canned responses.
