### PR TITLE
Extract out signing logic

### DIFF
--- a/lib/pusher.ex
+++ b/lib/pusher.ex
@@ -6,10 +6,8 @@ defmodule Pusher do
   """
   def trigger(event, data, channels, socket_id \\ nil) do
     data = encoded_data(data)
-    body = case socket_id do
-      nil -> %{name: event, channels: channel_list(channels), data: data}
-      _ -> %{name: event, channels: channel_list(channels), data: data, socket_id: socket_id}
-    end |> JSX.encode!
+    body = event_body(event, data, channels, socket_id)
+      |> JSX.encode!
     headers = %{"Content-type" => "application/json"}
     response = HttpClient.post!("/apps/#{app_id}/events", body, headers)
     if response_success?(response) do
@@ -17,6 +15,15 @@ defmodule Pusher do
     else
       :error
     end
+  end
+
+  defp event_body(event, data, channels, nil) do
+    %{name: event, channels: channel_list(channels), data: data}
+  end
+
+  defp event_body(event, data, channels, socket_id) do
+    event_body(event, data, channels, nil)
+      |> Dict.put(:socket_id, socket_id)
   end
 
   @doc """

--- a/lib/pusher/request_signer.ex
+++ b/lib/pusher/request_signer.ex
@@ -1,0 +1,20 @@
+defmodule Pusher.RequestSigner do
+  alias Signaturex.CryptoHelper
+
+  def sign_query_string(qs_vals, body, app_key, secret, method, path) do
+    qs_vals
+      |> add_body_md5(body)
+      |> sign(app_key, secret, method, path)
+  end
+
+  def add_body_md5(qs_vals, ""), do: qs_vals
+  def add_body_md5(qs_vals, body) do
+    Map.put(qs_vals, :body_md5, CryptoHelper.md5_to_string(body))
+  end
+
+  defp sign(qs_vals, app_key, secret, method, path) do
+    Signaturex.sign(app_key, secret, method, path, qs_vals)
+      |> Dict.merge(qs_vals)
+  end
+
+end

--- a/test/pusher/request_signer_test.exs
+++ b/test/pusher/request_signer_test.exs
@@ -1,0 +1,33 @@
+defmodule Pusher.RequestSignerTest do
+  use ExUnit.Case
+  import Pusher.RequestSigner
+  import Mock
+
+  @frozen_time 1353088179
+
+  test_with_mock "signs as expected", Signaturex.Time,
+  [stamp: fn() -> @frozen_time end] do
+
+    qs_vals = %{"some" => "value"}
+    body    = %{"name" => "foo",
+                "channels" => ["project-3"],
+                "data" => %{"some" => "data"}
+              } |> JSX.encode!
+    key     = "278d425bdf160c739803"
+    secret  = "7ad3773142a6692b25b8"
+    method  = :post
+    path    = "http://api.pusherapp.com/apps/3/events"
+
+    expected_result = %{
+      "some"           => "value",
+      :body_md5        => "5b37e2cd4b837a97b90ad2098f3c51c1",
+      "auth_key"       => key,
+      "auth_signature" => "e79fb000a4d4e6086398738fa884b9d68991c02c89d62eb2278e9f8ed3aa2bc4",
+      "auth_timestamp" => @frozen_time,
+      "auth_version"   => "1.0"
+    }
+
+    result = sign_query_string(qs_vals, body, key, secret, method, path)
+    assert result == expected_result
+  end
+end

--- a/test/pusher_test.exs
+++ b/test/pusher_test.exs
@@ -38,6 +38,20 @@ defmodule PusherTest do
     assert result == expected
   end
 
+  @expected_payload_with_socket_id %{
+    name: "event-name",
+    channels: ["channel"],
+    data: "data",
+    socket_id: "blah"
+    } |> JSX.encode!
+
+    test_with_mock ".trigger sends the payload with a socket_id", Pusher.HttpClient,
+    [post!: fn("/apps/app_id/events", @expected_payload_with_socket_id, _) -> @response_succesful_message end] do
+      result = Pusher.trigger("event-name", "data", "channel", "blah")
+      expected = :ok
+      assert result == expected
+    end
+
   @response_with_channel %HTTPoison.Response{
     body: %{"channels" => %{"test_channel" => %{}}},
     status_code: 200


### PR DESCRIPTION
This is based off the branch in PR #2 so please ignore for the moment.

It pulls the request signing logic out of the http client so this can have a small test to make sure it's signing the correct things.
