### PR TITLE
Gracefully handle errors when parsing response body

### DIFF
--- a/lib/pusher/http_client.ex
+++ b/lib/pusher/http_client.ex
@@ -4,7 +4,10 @@ defmodule Pusher.HttpClient do
   alias Pusher.Client
 
   def process_response_body(body) do
-    unless body == "", do: body |> Jason.decode!(), else: nil
+    case Jason.decode(body) do
+      {:ok, response} -> response
+      {:error, _reason} -> body
+    end
   end
 
   @doc """

--- a/test/pusher/http_client_test.exs
+++ b/test/pusher/http_client_test.exs
@@ -1,0 +1,36 @@
+defmodule Pusher.HttpClientTest do
+  use ExUnit.Case, async: true
+  alias Pusher.HttpClient
+
+  describe "process_response_body/1" do
+    test "json body" do
+      channels_response = """
+      {
+        "channels": {
+          "presence-foobar": {
+            "user_count": 42
+          }
+        }
+      }
+      """
+
+      expected = %{
+        "channels" => %{
+          "presence-foobar" => %{
+            "user_count" => 42
+          }
+        }
+      }
+
+      assert HttpClient.process_response_body(channels_response) == expected
+    end
+
+    test "invalid body" do
+      assert HttpClient.process_response_body("404 NOT FOUND\n") == "404 NOT FOUND\n"
+    end
+
+    test "empty body" do
+      assert HttpClient.process_response_body("") == ""
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

As described in #7 sometimes pusher responds with different body formats, that are not json, we need to take in considerations this scenarions when parsing the body to prevent exceptions from happening.

I personally caught this scenario when I wrongly defined the endpoint for pusher, instead of getting a beautifully constructed error struct from httpoison, I got the cryptic following message:

```
** (Jason.DecodeError) unexpected byte at position 4: 0x4E ('N')
    (jason) lib/jason.ex:78: Jason.decode!/2
    (httpoison) lib/httpoison/base.ex:866: HTTPoison.Base.response/8
    (pusher) lib/pusher.ex:16: Pusher.trigger/5
```

## Proposed solution

When parsing the response, if the JSON decoding is successful we return the decoded map, otherwise we return the plain body received. In that way we prevent having exception when the response is unexpected and return a map whenever possible.