### PR TITLE
Add support for OTP 24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,5 @@ matrix:
       otp_release: 21.0
     - elixir: 1.8
       otp_release: 22.0.1
+    - elixir: 1.12.3
+      otp_release: 24.0.2

--- a/lib/pusher/ws/pusher_event.ex
+++ b/lib/pusher/ws/pusher_event.ex
@@ -56,7 +56,11 @@ defmodule Pusher.WS.PusherEvent do
   end
 
   defp hmac256(app_secret, to_sign) do
-    :crypto.hmac(:sha256, app_secret, to_sign)
+    digest = if function_exported?(:crypto, :mac, 4),
+      do: :crypto.mac(:hmac, :sha256, app_secret, to_sign),
+      else: :crypto.hmac(:sha256, app_secret, to_sign)
+      
+    digest
     |> hexlify
     |> :string.to_lower()
     |> List.to_string()

--- a/lib/pusher/ws/pusher_event.ex
+++ b/lib/pusher/ws/pusher_event.ex
@@ -56,7 +56,7 @@ defmodule Pusher.WS.PusherEvent do
   end
 
   defp hmac256(app_secret, to_sign) do
-    digest = if function_exported?(:crypto, :mac, 4),
+    digest = if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :mac, 4),
       do: :crypto.mac(:hmac, :sha256, app_secret, to_sign),
       else: :crypto.hmac(:sha256, app_secret, to_sign)
       


### PR DESCRIPTION
`:crypto.hmac/3` was removed from OTP 24 along with several other "old API" functions. This swaps in the new `:crypto.mac/4` with a fallback for older OTP versions that only have the old API.

https://erlang.org/doc/apps/crypto/new_api.html